### PR TITLE
Remove plugins set to auto on

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ ENV LC_ALL="en_GB.UTF-8" \
 
 # Upgrade & install packages
 RUN add-apt-repository -y ppa:ondrej/php && \
-    add-apt-repository ppa:ondrej/nginx && \
+    add-apt-repository -y ppa:ondrej/nginx && \
     curl -sL https://deb.nodesource.com/setup_10.x | bash - && \
     apt-get update && \
     apt-get upgrade -y -o Dpkg::Options::="--force-confold" && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,17 +14,17 @@ ENV LC_ALL="en_GB.UTF-8" \
 
 # Upgrade & install packages
 RUN add-apt-repository -y ppa:ondrej/php && \
-    add-apt-repository -y ppa:nginx/stable && \
-    curl -sL https://deb.nodesource.com/setup_8.x | bash - && \
+    add-apt-repository ppa:ondrej/nginx && \
+    curl -sL https://deb.nodesource.com/setup_10.x | bash - && \
     apt-get update && \
     apt-get upgrade -y -o Dpkg::Options::="--force-confold" && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y \
-        php7.3-cli php7.3-curl php7.3-fpm php7.3-gd php7.3-mbstring php7.3-mysql php7.3-readline php-xdebug php7.3-xml php7.3-zip php-imagick \
+        php7.4-cli php7.4-curl php7.4-fpm php7.4-gd php7.4-mbstring php7.4-mysql php7.4-readline php-xdebug php7.4-xml php7.4-zip php-imagick \
         nginx nginx-extras\
-        python-pip libfuse-dev \
+        python3-pip libfuse-dev \
         nullmailer \
         git nano \
-        mariadb-client-10.1 \
+        mariadb-client-10.3 \
         nodejs build-essential \
         unzip && \
     apt-get clean && \
@@ -42,7 +42,7 @@ RUN curl -O https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli
 # Install yas3fs
 # Note: using a specific commit from master because there are changes waiting for release
 # Note (20/03/2019) removed specific commit - now on master
-RUN pip install git+https://github.com/danilop/yas3fs.git
+RUN pip3 install git+https://github.com/danilop/yas3fs.git
 
 ###
 # CONFIGURE PACKAGES
@@ -66,11 +66,11 @@ RUN mv /tmp/conf/nginx/server.conf /etc/nginx/sites-available/ && \
     ln -sf /dev/stderr /var/log/nginx/error.log
 
 # Configure php-fpm
-RUN mv /tmp/conf/php-fpm/php-fpm.conf /etc/php/7.3/fpm && \
-    mv /tmp/conf/php-fpm/php.ini /etc/php/7.3/fpm && \
-    mv /tmp/conf/php-fpm/pool.conf /etc/php/7.3/fpm/pool.d && \
-    rm /etc/php/7.3/fpm/pool.d/www.conf && \
-    cat /tmp/conf/php-fpm/xdebug.ini >> /etc/php/7.3/mods-available/xdebug.ini && \
+RUN mv /tmp/conf/php-fpm/php-fpm.conf /etc/php/7.4/fpm && \
+    mv /tmp/conf/php-fpm/php.ini /etc/php/7.4/fpm && \
+    mv /tmp/conf/php-fpm/pool.conf /etc/php/7.4/fpm/pool.d && \
+    rm /etc/php/7.4/fpm/pool.d/www.conf && \
+    cat /tmp/conf/php-fpm/xdebug.ini >> /etc/php/7.4/mods-available/xdebug.ini && \
     phpdismod xdebug
 
 # Configure cron tasks

--- a/conf/php-fpm/php-fpm.conf
+++ b/conf/php-fpm/php-fpm.conf
@@ -14,14 +14,14 @@
 ; Pid file
 ; Note: the default prefix is /var
 ; Default Value: none
-pid = /run/php7.3-fpm.pid
+pid = /run/php7.4-fpm.pid
 
 ; Error log file
 ; If it's set to "syslog", log is sent to syslogd instead of being written
 ; in a local file.
 ; Note: the default prefix is /var
 ; Default Value: log/php-fpm.log
-error_log = /var/log/php7.3-fpm.log
+error_log = /var/log/php7.4-fpm.log
 
 ; syslog_facility is used to specify what type of program is logging the
 ; message. This lets syslogd specify that messages from different facilities
@@ -122,4 +122,4 @@ daemonize = no
 ; Relative path can also be used. They will be prefixed by:
 ;  - the global prefix if it's been set (-p argument)
 ;  - /usr otherwise
-include=/etc/php/7.3/fpm/pool.d/*.conf
+include=/etc/php/7.4/fpm/pool.d/*.conf

--- a/init/configure-network.sh
+++ b/init/configure-network.sh
@@ -82,13 +82,7 @@ else
   echo "Activating plugins..."
 
   wp plugin --network --allow-root activate \
-    advanced-custom-fields-pro \
-    classic-editor \
-    fast-user-switching \
-    wp-analytify \
-    analytify-analytics-dashboard-widget \
-    wp-rewrite-media-to-s3 \
-    wordpress-seo
+    wp-rewrite-media-to-s3
 
   echo "Done :)"
   echo ""

--- a/service/php-fpm.sh
+++ b/service/php-fpm.sh
@@ -1,2 +1,2 @@
 #!/bin/sh
-exec /usr/sbin/php-fpm7.3
+exec /usr/sbin/php-fpm7.4


### PR DESCRIPTION
Main changes here:
- Update the version of NGINX we are using to be compatible with Ubuntu's latest Focal release - this required using ppa:ondrej/nginx version of nginx rather then nginx/stable which hasn't released an update for Focal yet on ppa. I would prefer just using nginx's version but ondrej's version should be fine considering we already use their PHP version.
- Updated Node 8 -> 10
- Update PHP 7.3 -> 7.4
- Update SQL client so that it is compatible with above. 
- Update Python -> Python3