### PR TITLE
Add security headers into NGINX

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -55,6 +55,7 @@ ADD conf/ /tmp/conf
 RUN mv /tmp/conf/nginx/server.conf /etc/nginx/sites-available/ && \
     mv /tmp/conf/nginx/multisite.conf /etc/nginx/ && \
     mv /tmp/conf/nginx/php-fpm.conf /etc/nginx/ && \
+    mv /tmp/conf/nginx/headers.conf /etc/nginx/snippets/ && \
     mkdir /etc/nginx/whitelists/ && \
     echo "daemon off;" >> /etc/nginx/nginx.conf && \
     echo "# No frontend IP whitelist configured. Come one, come all!" > /etc/nginx/whitelists/site-wide.conf && \

--- a/conf/nginx/headers.conf
+++ b/conf/nginx/headers.conf
@@ -1,0 +1,6 @@
+add_header X-Frame-Options SAMEORIGIN always;
+add_header X-XSS-Protection "1; mode=block" always;
+add_header X-Content-Type-Options nosniff always;
+add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
+add_header Access-Control-Allow-Origin "*" always;
+add_header Content-Security-Policy-Report-Only "script-src 'self' 'unsafe-inline' 'unsafe-eval' https://*.wp.dsd.io *.youtube.com maps.gstatic.com *.googletagmanager.com *.googleapis.com *.google-analytics.com connect.facebook.net; img-src 'self' data: https://*.amazonaws.com https://www.google-analytics.com; font-src 'self' data: https://fonts.gstatic.com https://*.prod.wp.dsd.io; frame-src 'self' *.youtube.com *.facebook.com s-static.ak.facebook.com; object-src 'self'; report-uri '/csp-violation-report-endpoint-to-be-added/'; report-to '/csp-violation-report-endpoint-to-be-added/';" always;

--- a/conf/nginx/server.conf
+++ b/conf/nginx/server.conf
@@ -90,6 +90,9 @@ server {
 	# Frontend IP whitelist
 	include /etc/nginx/whitelists/site-wide.conf;
 
+	# Add security headers
+	include /etc/nginx/snippets/headers.conf;
+
 	# deny access to dotfiles and dotdirectories, except .well-known
     # this will deny access to .git, .htaccess, .env, and other sensitive files
     location ~ /\.(?!well-known).* {
@@ -114,6 +117,7 @@ server {
 	# pass PHP requests to php-fpm
 	location ~ \.php$ {
 		include /etc/nginx/php-fpm.conf;
+		include /etc/nginx/snippets/headers.conf;
 	}
 
     #avoid php readfile()
@@ -129,6 +133,7 @@ server {
 
 		include /etc/nginx/whitelists/wp-login.conf;
 		include /etc/nginx/php-fpm.conf;
+		include /etc/nginx/snippets/headers.conf;
 	}
 
 	location ~ /purge-cache(/.*) {


### PR DESCRIPTION
Re-bug font-awesome icons not appearing on magi rec, I've updated our
NGINX files to serve new security headers. I've added in a whole suite
of security headers in one go. Notably the CSC header I've left as
report only for now. We have so many various scripts/styles third party
boltons that from a CSC policy the I/O involved in creating the
appropiate policy is quite difficult. I've made a good start and if
nothing gets blocked we can impliment a blocking CSC.