### PR TITLE
Fix Robots file location so Wordpress generates it

### DIFF
--- a/conf/nginx/server.conf
+++ b/conf/nginx/server.conf
@@ -140,7 +140,11 @@ server {
 		fastcgi_cache_purge pub01 "$real_scheme$request_method$host$1";
 	}
 
-	location = /robots.txt { allow all; access_log off; log_not_found off; }
+	location = /robots.txt {
+        try_files $uri $uri/ /index.php?$args;
+        access_log off;
+        log_not_found off;
+    }
 
 	##
 	# GZIP COMPRESSION


### PR DESCRIPTION
We are adding this for IMA and for future sites so we can manage the robots file per site.